### PR TITLE
Bugfix phpunit bootstrap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "lstrojny/phpunit-function-mocker": "^0.3 || ^0.4",
         "phpunit/dbunit": "^1.3 || ^3.0",
         "phpunit/php-code-coverage": "^2.0 || ^4.0",
-        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.4",
+        "phpunit/phpunit": "^5.7 || ^6.4",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",
         "roave/security-advisories": "dev-master@dev",

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "league/flysystem-memory": "^1.0",
         "lstrojny/phpunit-function-mocker": "^0.3 || ^0.4",
         "phpunit/dbunit": "^1.3 || ^3.0",
-        "phpunit/php-code-coverage": "^2.0 || ^4.0",
+        "phpunit/php-code-coverage": "^4.0",
         "phpunit/phpunit": "^5.7 || ^6.4",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -14,7 +14,7 @@ if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
 
 // Install base location
 if (!defined('TEST_ROOT')) {
-    define('TEST_ROOT', realpath(__DIR__ . '/../../'));
+    define('TEST_ROOT', dirname(dirname(__DIR__)));
 }
 
 // PHPUnit's base location

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,8 +2,14 @@
 
 if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../vendor/autoload.php';
-} else {
+} elseif (file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../../../vendor/autoload.php';
+} else {
+    exit('Could not find the vendor autoloader');
 }
 
 // Install base location


### PR DESCRIPTION
When using an old version of phpunit like `4.8.28` it does not provide a class called `PHPUnit\Framework\TestCase` required by `bolt/bolt/tests/phpunit/unit/BoltUnitTest.php`
The class is available in version 5.7. The dependancy with `phpunit/php-code-coverage` has also been updated.

Next to the phpunit version there is an issue when running the unittests, it can't seem to find the `vendor/autoload.php`. I've made the bootstrap a bit more defensive.
For context: We have the bootstrap located in: `vendor/bolt/bolt/tests/phpunit/bootstrap.php`

See: https://github.com/bolt/bolt/pull/7763